### PR TITLE
better way of using UserId for start/end session use cases

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -4,10 +4,6 @@ import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Dimension;
 
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.WindowConstants;
-
 import entity.StudyQuizFactory;
 import entity.StudySessionFactory;
 import entity.UserFactory;
@@ -61,6 +57,10 @@ import view.StudySessionView;
 import view.UploadMaterialsView;
 import view.UploadSessionMaterialsView;
 import view.ViewManager;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.WindowConstants;
 
 public class AppBuilder {
     public static final ViewManagerModel viewManagerModel = new ViewManagerModel();
@@ -218,7 +218,7 @@ public class AppBuilder {
         StartStudySessionInteractor configStudySessionInteractor = new StartStudySessionInteractor(
             startStudySessionPresenter, fileDataAccessObject);
         StartStudySessionController studySessionConfigController = new StartStudySessionController(
-            configStudySessionInteractor);
+            configStudySessionInteractor, dashboardViewModel);
         studySessionConfigView.setStartStudySessionController(studySessionConfigController);
         return this;
     }
@@ -252,7 +252,8 @@ public class AppBuilder {
         EndStudySessionInteractor endStudySessionInteractor = new EndStudySessionInteractor(endStudySessionPresenter,
             studySessionDataAccessObject,
             studySessionFactory);
-        EndStudySessionController endStudySessionController = new EndStudySessionController(endStudySessionInteractor);
+        EndStudySessionController endStudySessionController =
+            new EndStudySessionController(endStudySessionInteractor, dashboardViewModel);
         studySessionView.addEndStudySessionController(endStudySessionController);
         return this;
     }
@@ -286,7 +287,7 @@ public class AppBuilder {
         ViewStudyMetricsPresenter presenter = new ViewStudyMetricsPresenter(metricsViewModel);
 
         ViewStudyMetricsDataAccessInterface metricsDAO = new FirebaseMetricsDataAccessObject(
-                studySessionDataAccessObject, quizDataAccessObject);
+            studySessionDataAccessObject, quizDataAccessObject);
         ViewStudyMetricsInteractor interactor = new ViewStudyMetricsInteractor(metricsDAO, presenter);
 
         ViewStudyMetricsController controller = new ViewStudyMetricsController(interactor, dashboardViewModel);

--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -196,7 +196,7 @@ public class AppBuilder {
 
     public AppBuilder addStudySessionView() {
         studySessionViewModel = new StudySessionViewModel();
-        studySessionView = new StudySessionView(studySessionViewModel);
+        studySessionView = new StudySessionView(studySessionViewModel, dashboardViewModel);
 
         cardPanel.add(studySessionView, studySessionView.getViewName());
         return this;
@@ -204,7 +204,7 @@ public class AppBuilder {
 
     public AppBuilder addStudySessionConfigView() {
         studySessionConfigViewModel = new StudySessionConfigViewModel();
-        studySessionConfigView = new StudySessionConfigView(studySessionConfigViewModel);
+        studySessionConfigView = new StudySessionConfigView(studySessionConfigViewModel, dashboardViewModel);
         cardPanel.add(studySessionConfigView, studySessionConfigView.getViewName());
         return this;
     }
@@ -218,7 +218,7 @@ public class AppBuilder {
         StartStudySessionInteractor configStudySessionInteractor = new StartStudySessionInteractor(
             startStudySessionPresenter, fileDataAccessObject);
         StartStudySessionController studySessionConfigController = new StartStudySessionController(
-            configStudySessionInteractor, dashboardViewModel);
+            configStudySessionInteractor);
         studySessionConfigView.setStartStudySessionController(studySessionConfigController);
         return this;
     }
@@ -253,7 +253,7 @@ public class AppBuilder {
             studySessionDataAccessObject,
             studySessionFactory);
         EndStudySessionController endStudySessionController =
-            new EndStudySessionController(endStudySessionInteractor, dashboardViewModel);
+            new EndStudySessionController(endStudySessionInteractor);
         studySessionView.addEndStudySessionController(endStudySessionController);
         return this;
     }

--- a/src/main/java/frameworks_drivers/firebase/FirebaseMetricsDataAccessObject.java
+++ b/src/main/java/frameworks_drivers/firebase/FirebaseMetricsDataAccessObject.java
@@ -44,7 +44,7 @@ public class FirebaseMetricsDataAccessObject implements ViewStudyMetricsDataAcce
         LocalDateTime start = currentTime.truncatedTo(ChronoUnit.DAYS);
         LocalDateTime end = currentTime.plusDays(7).truncatedTo(ChronoUnit.DAYS).minusNanos(1);
 
-        List<StudyQuiz> quizzes = quizDAO.getStudyQuizzesInRange(DashboardState.userId, start, end);
+        List<StudyQuiz> quizzes = quizDAO.getStudyQuizzesInRange(userId, start, end);
 
         return quizzes;
     }

--- a/src/main/java/interface_adapter/controller/EndStudySessionController.java
+++ b/src/main/java/interface_adapter/controller/EndStudySessionController.java
@@ -1,5 +1,6 @@
 package interface_adapter.controller;
 
+import interface_adapter.view_model.DashboardViewModel;
 import interface_adapter.view_model.StudySessionState;
 import use_case.end_study_session.EndStudySessionInputBoundary;
 import use_case.end_study_session.EndStudySessionInputData;
@@ -9,9 +10,11 @@ import use_case.end_study_session.EndStudySessionInputData;
  */
 public class EndStudySessionController {
     private final EndStudySessionInputBoundary interactor;
+    private final DashboardViewModel dashboardViewModel;
 
-    public EndStudySessionController(EndStudySessionInputBoundary interactor) {
+    public EndStudySessionController(EndStudySessionInputBoundary interactor, DashboardViewModel dashboardViewModel) {
         this.interactor = interactor;
+        this.dashboardViewModel = dashboardViewModel;
     }
 
     /**
@@ -20,7 +23,8 @@ public class EndStudySessionController {
      * @param state The current state of the study session
      */
     public void execute(StudySessionState state) {
-        final EndStudySessionInputData inputData = new EndStudySessionInputData(state);
+        final EndStudySessionInputData inputData =
+            new EndStudySessionInputData(dashboardViewModel.getState().getUserId(), state);
         interactor.execute(inputData);
 
     }

--- a/src/main/java/interface_adapter/controller/EndStudySessionController.java
+++ b/src/main/java/interface_adapter/controller/EndStudySessionController.java
@@ -10,21 +10,20 @@ import use_case.end_study_session.EndStudySessionInputData;
  */
 public class EndStudySessionController {
     private final EndStudySessionInputBoundary interactor;
-    private final DashboardViewModel dashboardViewModel;
 
-    public EndStudySessionController(EndStudySessionInputBoundary interactor, DashboardViewModel dashboardViewModel) {
+    public EndStudySessionController(EndStudySessionInputBoundary interactor) {
         this.interactor = interactor;
-        this.dashboardViewModel = dashboardViewModel;
     }
 
     /**
      * Ends the study session.
      *
+     * @param userId the user Id
      * @param state The current state of the study session
      */
-    public void execute(StudySessionState state) {
+    public void execute(String userId, StudySessionState state) {
         final EndStudySessionInputData inputData =
-            new EndStudySessionInputData(dashboardViewModel.getState().getUserId(), state);
+            new EndStudySessionInputData(userId, state);
         interactor.execute(inputData);
 
     }

--- a/src/main/java/interface_adapter/controller/StartStudySessionController.java
+++ b/src/main/java/interface_adapter/controller/StartStudySessionController.java
@@ -9,23 +9,21 @@ import use_case.start_study_session.StartStudySessionInputData;
  * Controller for starting a study session.
  */
 public class StartStudySessionController {
-    private final DashboardViewModel dashboardViewModel;
     private final StartStudySessionInputBoundary interactor;
 
-    public StartStudySessionController(StartStudySessionInputBoundary interactor,
-                                       DashboardViewModel dashboardViewModel) {
+    public StartStudySessionController(StartStudySessionInputBoundary interactor) {
         this.interactor = interactor;
-        this.dashboardViewModel = dashboardViewModel;
     }
 
     /**
      * Attempts to start a study session with the current config.
      *
+     * @param userId the current state
      * @param state The current configuration
      */
-    public void execute(StudySessionConfigState state) {
+    public void execute(String userId, StudySessionConfigState state) {
         final StartStudySessionInputData inputData = new StartStudySessionInputData(
-            dashboardViewModel.getState().getUserId(),
+            userId,
             state.copy());
         interactor.execute(inputData);
     }
@@ -39,8 +37,10 @@ public class StartStudySessionController {
 
     /**
      * Refresh the file options that are available.
+     *
+     * @param userId The User ID
      */
-    public void refreshFileOptions() {
-        interactor.refreshFileOptions(dashboardViewModel.getState().getUserId());
+    public void refreshFileOptions(String userId) {
+        interactor.refreshFileOptions(userId);
     }
 }

--- a/src/main/java/interface_adapter/controller/StartStudySessionController.java
+++ b/src/main/java/interface_adapter/controller/StartStudySessionController.java
@@ -1,5 +1,6 @@
 package interface_adapter.controller;
 
+import interface_adapter.view_model.DashboardViewModel;
 import interface_adapter.view_model.StudySessionConfigState;
 import use_case.start_study_session.StartStudySessionInputBoundary;
 import use_case.start_study_session.StartStudySessionInputData;
@@ -8,10 +9,13 @@ import use_case.start_study_session.StartStudySessionInputData;
  * Controller for starting a study session.
  */
 public class StartStudySessionController {
+    private final DashboardViewModel dashboardViewModel;
     private final StartStudySessionInputBoundary interactor;
 
-    public StartStudySessionController(StartStudySessionInputBoundary interactor) {
+    public StartStudySessionController(StartStudySessionInputBoundary interactor,
+                                       DashboardViewModel dashboardViewModel) {
         this.interactor = interactor;
+        this.dashboardViewModel = dashboardViewModel;
     }
 
     /**
@@ -21,6 +25,7 @@ public class StartStudySessionController {
      */
     public void execute(StudySessionConfigState state) {
         final StartStudySessionInputData inputData = new StartStudySessionInputData(
+            dashboardViewModel.getState().getUserId(),
             state.copy());
         interactor.execute(inputData);
     }
@@ -36,6 +41,6 @@ public class StartStudySessionController {
      * Refresh the file options that are available.
      */
     public void refreshFileOptions() {
-        interactor.refreshFileOptions();
+        interactor.refreshFileOptions(dashboardViewModel.getState().getUserId());
     }
 }

--- a/src/main/java/interface_adapter/presenter/StartStudySessionPresenter.java
+++ b/src/main/java/interface_adapter/presenter/StartStudySessionPresenter.java
@@ -45,8 +45,6 @@ public class StartStudySessionPresenter implements StartStudySessionOutputBounda
 
         // Navigate to study session view
         viewManagerModel.setView(studySessionViewModel.getViewName());
-        viewManagerModel.firePropertyChange();
-
     }
 
     @Override

--- a/src/main/java/interface_adapter/view_model/DashboardState.java
+++ b/src/main/java/interface_adapter/view_model/DashboardState.java
@@ -4,7 +4,7 @@ package interface_adapter.view_model;
  * The State information representing the logged-in user and dashboard data.
  */
 public class DashboardState {
-    public static String userId = "";
+    private String userId = "";
     private String email = "";
 
     public DashboardState(DashboardState copy) {

--- a/src/main/java/use_case/end_study_session/EndStudySessionInputData.java
+++ b/src/main/java/use_case/end_study_session/EndStudySessionInputData.java
@@ -7,9 +7,15 @@ import interface_adapter.view_model.StudySessionState;
  */
 public class EndStudySessionInputData {
     private final StudySessionState studySessionState;
+    private final String userId;
 
-    public EndStudySessionInputData(StudySessionState studySessionState) {
+    public EndStudySessionInputData(String userId, StudySessionState studySessionState) {
         this.studySessionState = studySessionState;
+        this.userId = userId;
+    }
+
+    public String getUserId() {
+        return userId;
     }
 
     public StudySessionState getStudySessionState() {

--- a/src/main/java/use_case/end_study_session/EndStudySessionInteractor.java
+++ b/src/main/java/use_case/end_study_session/EndStudySessionInteractor.java
@@ -38,8 +38,7 @@ public class EndStudySessionInteractor implements EndStudySessionInputBoundary {
             sessionState.getStartTime(),
             endTime);
 
-        // TODO: MAke User ID handling, well, real
-        final StudySession savedSession = sessionDataAccessObject.addStudySession(DashboardState.userId, session);
+        final StudySession savedSession = sessionDataAccessObject.addStudySession(inputData.getUserId(), session);
         final String sessionId = savedSession.getId();
 
         final EndStudySessionOutputData outputData = new EndStudySessionOutputData(

--- a/src/main/java/use_case/start_study_session/StartStudySessionInputBoundary.java
+++ b/src/main/java/use_case/start_study_session/StartStudySessionInputBoundary.java
@@ -18,6 +18,8 @@ public interface StartStudySessionInputBoundary {
 
     /**
      * Refresh the list of file options available to the user.
+     *
+     * @param userId The userID for the user
      */
-    void refreshFileOptions();
+    void refreshFileOptions(String userId);
 }

--- a/src/main/java/use_case/start_study_session/StartStudySessionInputData.java
+++ b/src/main/java/use_case/start_study_session/StartStudySessionInputData.java
@@ -6,13 +6,19 @@ import interface_adapter.view_model.StudySessionConfigState;
  * The input data for starting a study session. Includes the currently set configuration by the user.
  */
 public class StartStudySessionInputData {
+    private final String userId;
     private final StudySessionConfigState config;
 
-    public StartStudySessionInputData(StudySessionConfigState config) {
+    public StartStudySessionInputData(String userId, StudySessionConfigState config) {
+        this.userId = userId;
         this.config = config;
     }
 
     public StudySessionConfigState getConfig() {
         return config;
+    }
+
+    public String getUserId() {
+        return userId;
     }
 }

--- a/src/main/java/use_case/start_study_session/StartStudySessionInteractor.java
+++ b/src/main/java/use_case/start_study_session/StartStudySessionInteractor.java
@@ -3,7 +3,6 @@ package use_case.start_study_session;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import interface_adapter.view_model.DashboardState;
 import interface_adapter.view_model.StudySessionConfigState;
 import interface_adapter.view_model.StudySessionConfigState.SessionType;
 
@@ -28,7 +27,7 @@ public class StartStudySessionInteractor implements StartStudySessionInputBounda
     @Override
     public void execute(StartStudySessionInputData inputData) {
         final StudySessionConfigState config = inputData.getConfig();
-
+        final String userId = inputData.getUserId();
         // Validate.
         if (config.getSessionType() == null) {
             presenter.prepareErrorView("You need a session type selected.");
@@ -40,7 +39,7 @@ public class StartStudySessionInteractor implements StartStudySessionInputBounda
         else if (config.getReferenceFile() == null || config.getReferenceFile().isEmpty()) {
             presenter.prepareErrorView("Please select a reference file.");
         }
-        else if (!checkIfFileExists(config.getReferenceFile())) {
+        else if (!checkIfFileExists(userId, config.getReferenceFile())) {
             presenter.prepareErrorView("Reference file does not exist in storage..? Use another one.");
         }
         else if (config.getPrompt() == null || config.getPrompt().isEmpty()) {
@@ -64,22 +63,22 @@ public class StartStudySessionInteractor implements StartStudySessionInputBounda
     /**
      * Check if the given file resource exists in storage.
      *
-     * @param file The file to check.
+     * @param userId The id of the current user
+     * @param file   The file to check.
      * @return whether the file exists.
      */
-    private boolean checkIfFileExists(String file) {
-        // TODO: MMake User ID handling, well, real
-        return fileDataAccessObject.fileExistsByName(DashboardState.userId, file);
+    private boolean checkIfFileExists(String userId, String file) {
+        return fileDataAccessObject.fileExistsByName(userId, file);
     }
 
     // TODO: Either remove this and move this to navigation from dashboard to config
     // view, or
     // make sure this is called when the config view is opened somehow.
     @Override
-    public void refreshFileOptions() {
+    public void refreshFileOptions(String userId) {
 
         // TODO: Use real user ID
-        List<String> fileOptions = fileDataAccessObject.getAllUserFiles(DashboardState.userId);
+        final List<String> fileOptions = fileDataAccessObject.getAllUserFiles(userId);
         if (fileOptions == null || fileOptions.isEmpty()) {
             presenter.prepareErrorView("No textbook files. Go to the settings and add some first.");
             presenter.abortStudySessionConfig();

--- a/src/main/java/view/StudyQuizView.java
+++ b/src/main/java/view/StudyQuizView.java
@@ -147,7 +147,7 @@ public class StudyQuizView extends View {
                 float score = (float) correctAnswers / questions.size();
                 StudyQuiz quiz = new StudyQuizFactory().create(score,
                         LocalDateTime.now(), LocalDateTime.now());
-                quizDAO.addStudyQuiz(DashboardState.userId,
+                quizDAO.addStudyQuiz("JGioTqVXbwdu7plKFsMcjdCBwKf1",
                         quiz);
             }
         });

--- a/src/main/java/view/StudySessionConfigView.java
+++ b/src/main/java/view/StudySessionConfigView.java
@@ -24,10 +24,10 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
-import interface_adapter.view_model.DashboardViewModel;
 import org.jetbrains.annotations.NotNull;
 
 import interface_adapter.controller.StartStudySessionController;
+import interface_adapter.view_model.DashboardViewModel;
 import interface_adapter.view_model.StudySessionConfigState;
 import interface_adapter.view_model.StudySessionConfigState.SessionType;
 import interface_adapter.view_model.StudySessionConfigViewModel;
@@ -57,10 +57,9 @@ public class StudySessionConfigView extends StatefulView<StudySessionConfigState
     private final JTextArea promptArea = new JTextArea(4, 40);
     private final JComboBox<String> typeSelector = new JComboBox<>();
     private final JComboBox<String> fileSelector = new JComboBox<>();
-
-    private StartStudySessionController startStudySessionController;
     private final DashboardViewModel dashboardViewModel;
-    
+    private StartStudySessionController startStudySessionController;
+
     public StudySessionConfigView(StudySessionConfigViewModel viewModel, DashboardViewModel dashboardViewModel) {
         super("studySessionConfig", viewModel);
         this.dashboardViewModel = dashboardViewModel;
@@ -81,7 +80,8 @@ public class StudySessionConfigView extends StatefulView<StudySessionConfigState
         cancelButton.addActionListener(event -> startStudySessionController.abortStudySessionConfig());
         nextButton.addActionListener(event -> {
             final StudySessionConfigState currentConfig = viewModel.getState().copy();
-            startStudySessionController.execute(dashboardViewModel.getState().getUserId(), currentConfig);
+            startStudySessionController.execute(
+                this.dashboardViewModel.getState().getUserId(), currentConfig);
         });
 
         navigationContainer.add(cancelButton);
@@ -95,8 +95,8 @@ public class StudySessionConfigView extends StatefulView<StudySessionConfigState
 
         final JButton refreshButton = new JButton("Refresh File List");
         refreshButton.addActionListener(event -> {
-            startStudySessionController.refreshFileOptions(
-                    dashboardViewModel.getState().getUserId());
+                startStudySessionController.refreshFileOptions(
+                    this.dashboardViewModel.getState().getUserId());
             }
         );
 

--- a/src/main/java/view/StudySessionConfigView.java
+++ b/src/main/java/view/StudySessionConfigView.java
@@ -24,6 +24,7 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import interface_adapter.view_model.DashboardViewModel;
 import org.jetbrains.annotations.NotNull;
 
 import interface_adapter.controller.StartStudySessionController;
@@ -58,10 +59,11 @@ public class StudySessionConfigView extends StatefulView<StudySessionConfigState
     private final JComboBox<String> fileSelector = new JComboBox<>();
 
     private StartStudySessionController startStudySessionController;
-
-    public StudySessionConfigView(StudySessionConfigViewModel viewModel) {
+    private final DashboardViewModel dashboardViewModel;
+    
+    public StudySessionConfigView(StudySessionConfigViewModel viewModel, DashboardViewModel dashboardViewModel) {
         super("studySessionConfig", viewModel);
-
+        this.dashboardViewModel = dashboardViewModel;
         final JPanel viewHeader = new ViewHeader("Session Config");
         final JPanel main = new JPanel();
         main.setLayout(new BoxLayout(main, BoxLayout.Y_AXIS));
@@ -79,7 +81,7 @@ public class StudySessionConfigView extends StatefulView<StudySessionConfigState
         cancelButton.addActionListener(event -> startStudySessionController.abortStudySessionConfig());
         nextButton.addActionListener(event -> {
             final StudySessionConfigState currentConfig = viewModel.getState().copy();
-            startStudySessionController.execute(currentConfig);
+            startStudySessionController.execute(dashboardViewModel.getState().getUserId(), currentConfig);
         });
 
         navigationContainer.add(cancelButton);
@@ -92,7 +94,11 @@ public class StudySessionConfigView extends StatefulView<StudySessionConfigState
         main.add(navigationContainer);
 
         final JButton refreshButton = new JButton("Refresh File List");
-        refreshButton.addActionListener(event -> startStudySessionController.refreshFileOptions());
+        refreshButton.addActionListener(event -> {
+            startStudySessionController.refreshFileOptions(
+                    dashboardViewModel.getState().getUserId());
+            }
+        );
 
         viewHeader.add(refreshButton, BorderLayout.EAST);
 

--- a/src/main/java/view/StudySessionView.java
+++ b/src/main/java/view/StudySessionView.java
@@ -40,9 +40,11 @@ public class StudySessionView extends StatefulView<StudySessionState> {
     private final JLabel headerLabel = new JLabel();
     private final Timer uiTimer;
     private EndStudySessionController endStudySessionController;
+    private DashboardViewModel dashboardViewModel;
 
     public StudySessionView(StudySessionViewModel studySessionViewModel, DashboardViewModel dashboardViewModel) {
         super("studySession", studySessionViewModel);
+        this.dashboardViewModel = dashboardViewModel;
 
         final JPanel main = new JPanel();
         main.setLayout(new BoxLayout(main, BoxLayout.Y_AXIS));
@@ -62,14 +64,16 @@ public class StudySessionView extends StatefulView<StudySessionState> {
             if (viewModel.getState().getSessionType() == StudySessionConfigState.SessionType.FIXED
                 && viewModel.getState().getRemainingDuration().isZero()) {
                 final StudySessionState state = viewModel.getState();
-                endStudySessionController.execute(dashboardViewModel.getState().getUserId(), state);
+                endStudySessionController.execute(
+                    this.dashboardViewModel.getState().getUserId(), state);
             }
         });
 
         final JButton finalizeSession = new JButton("Finalize Session");
         finalizeSession.addActionListener(event -> {
             final StudySessionState state = viewModel.getState();
-            endStudySessionController.execute(dashboardViewModel.getState().getUserId(), state);
+            endStudySessionController.execute(
+                this.dashboardViewModel.getState().getUserId(), state);
         });
         finalizeSession.setAlignmentX(Component.CENTER_ALIGNMENT);
 

--- a/src/main/java/view/StudySessionView.java
+++ b/src/main/java/view/StudySessionView.java
@@ -16,6 +16,7 @@ import javax.swing.JPanel;
 import javax.swing.Timer;
 
 import interface_adapter.controller.EndStudySessionController;
+import interface_adapter.view_model.DashboardViewModel;
 import interface_adapter.view_model.StudySessionConfigState;
 import interface_adapter.view_model.StudySessionState;
 import interface_adapter.view_model.StudySessionViewModel;
@@ -40,7 +41,7 @@ public class StudySessionView extends StatefulView<StudySessionState> {
     private final Timer uiTimer;
     private EndStudySessionController endStudySessionController;
 
-    public StudySessionView(StudySessionViewModel studySessionViewModel) {
+    public StudySessionView(StudySessionViewModel studySessionViewModel, DashboardViewModel dashboardViewModel) {
         super("studySession", studySessionViewModel);
 
         final JPanel main = new JPanel();
@@ -61,14 +62,14 @@ public class StudySessionView extends StatefulView<StudySessionState> {
             if (viewModel.getState().getSessionType() == StudySessionConfigState.SessionType.FIXED
                 && viewModel.getState().getRemainingDuration().isZero()) {
                 final StudySessionState state = viewModel.getState();
-                endStudySessionController.execute(state);
+                endStudySessionController.execute(dashboardViewModel.getState().getUserId(), state);
             }
         });
 
         final JButton finalizeSession = new JButton("Finalize Session");
         finalizeSession.addActionListener(event -> {
             final StudySessionState state = viewModel.getState();
-            endStudySessionController.execute(state);
+            endStudySessionController.execute(dashboardViewModel.getState().getUserId(), state);
         });
         finalizeSession.setAlignmentX(Component.CENTER_ALIGNMENT);
 

--- a/src/test/java/use_case/end_study_session/EndStudySessionTest.java
+++ b/src/test/java/use_case/end_study_session/EndStudySessionTest.java
@@ -1,21 +1,21 @@
 package use_case.end_study_session;
 
+import java.time.LocalDateTime;
+
+import entity.StudySessionFactory;
 import frameworks_drivers.database.InMemoryDatabase;
 import interface_adapter.view_model.StudySessionConfigState;
 import interface_adapter.view_model.StudySessionState;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.Test;
-
-import entity.StudySessionFactory;
-
-import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class EndStudySessionTest {
 
     @Test
     void successSavedSessionTest() {
-        StudySessionState sessionState = new StudySessionState();
+        final StudySessionState sessionState = new StudySessionState();
 
         // Assume session started 1 hour ago (doesn't matter really)
         sessionState.setStartTime(LocalDateTime.now().minusHours(1));
@@ -25,12 +25,13 @@ class EndStudySessionTest {
         sessionState.setReferenceFile("csc236.pdf");
         sessionState.setPrompt("Recursive correctness");
 
-        EndStudySessionDataAccessInterface sessionRepository = new InMemoryDatabase();
+        final EndStudySessionDataAccessInterface sessionRepository = new InMemoryDatabase();
 
-        EndStudySessionInputData inputData = new EndStudySessionInputData(
-                sessionState);
+        final EndStudySessionInputData inputData = new EndStudySessionInputData(
+            "testUser",
+            sessionState);
 
-        EndStudySessionOutputBoundary presenter = new EndStudySessionOutputBoundary() {
+        final EndStudySessionOutputBoundary presenter = new EndStudySessionOutputBoundary() {
             @Override
             public void prepareEndView(EndStudySessionOutputData outputData) {
                 // Assert the session has ended
@@ -44,9 +45,9 @@ class EndStudySessionTest {
             }
         };
 
-        EndStudySessionInteractor interactor = new EndStudySessionInteractor(presenter,
-                sessionRepository,
-                new StudySessionFactory());
+        final EndStudySessionInteractor interactor = new EndStudySessionInteractor(presenter,
+            sessionRepository,
+            new StudySessionFactory());
         interactor.execute(inputData);
     }
 }

--- a/src/test/java/use_case/start_study_session/StartStudySessionTest.java
+++ b/src/test/java/use_case/start_study_session/StartStudySessionTest.java
@@ -1,44 +1,52 @@
 package use_case.start_study_session;
 
-import frameworks_drivers.database.InMemoryDatabase;
-import interface_adapter.view_model.StudySessionConfigState;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+import frameworks_drivers.database.InMemoryDatabase;
+import interface_adapter.view_model.StudySessionConfigState;
 
 class StartStudySessionTest {
 
     @Test
     void startFixedStudySessionTest() {
-        StartStudySessionDataAccessInterface database = new InMemoryDatabase(
-                Map.of("csc236.pdf", "csc236.pdf"));
-        StudySessionConfigState config = new StudySessionConfigState();
+        final int durationHours = 2;
+        final int durationMins = 30;
+        final int minPerHour = 60;
+
+        final StartStudySessionDataAccessInterface database = new InMemoryDatabase(
+            Map.of("csc236.pdf", "csc236.pdf"));
+        final StudySessionConfigState config = new StudySessionConfigState();
         config.setSessionType(StudySessionConfigState.SessionType.FIXED);
-        config.setTargetDurationHours(2);
-        config.setTargetDurationMinutes(30);
+        config.setTargetDurationHours(durationHours);
+        config.setTargetDurationMinutes(durationMins);
         config.setReferenceFile("csc236.pdf");
         config.setPrompt("Recursive correctness");
 
-        StartStudySessionInputData inputData = new StartStudySessionInputData(
-                config
+        final StartStudySessionInputData inputData = new StartStudySessionInputData(
+            "testUser",
+            config
         );
 
-        StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
-
+        final StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
             @Override
             public void startStudySession(StartStudySessionOutputData outputData) {
-                StudySessionConfigState outputState = outputData.getConfig();
+                final StudySessionConfigState outputState = outputData.getConfig();
 
                 // Check if final output config state correct
                 assertEquals(StudySessionConfigState.SessionType.FIXED, outputState.getSessionType());
-                assertEquals(2 * 60 + 30, outputState.getTotalTargetDurationMinutes());
+                assertEquals(durationHours * minPerHour + durationMins, outputState.getTotalTargetDurationMinutes());
                 assertEquals("Recursive correctness", outputState.getPrompt());
                 assertEquals("csc236.pdf", outputState.getReferenceFile());
 
-                assertNotNull(outputData.getStartTime()); // Make sure a start time was provided
+                // Make sure a start time was provided
+                assertNotNull(outputData.getStartTime());
             }
 
             @Override
@@ -57,36 +65,37 @@ class StartStudySessionTest {
             }
         };
 
-        StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter, database);
+        final StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter, database);
         interactor.execute(inputData);
 
     }
 
     @Test
     void startVariableStudySessionTest() {
-        StartStudySessionDataAccessInterface database = new InMemoryDatabase(
-                Map.of("csc236.pdf", "csc236.pdf"));
-        StudySessionConfigState config = new StudySessionConfigState();
+        final StartStudySessionDataAccessInterface database = new InMemoryDatabase(
+            Map.of("csc236.pdf", "csc236.pdf"));
+        final StudySessionConfigState config = new StudySessionConfigState();
         config.setSessionType(StudySessionConfigState.SessionType.VARIABLE);
         config.setReferenceFile("csc236.pdf");
         config.setPrompt("Recursive correctness");
 
-        StartStudySessionInputData inputData = new StartStudySessionInputData(
-                config
+        final StartStudySessionInputData inputData = new StartStudySessionInputData(
+            "testUser",
+            config
         );
 
-        StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
-
+        final StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
             @Override
             public void startStudySession(StartStudySessionOutputData outputData) {
-                StudySessionConfigState outputState = outputData.getConfig();
+                final StudySessionConfigState outputState = outputData.getConfig();
 
                 // Check if final output config state correct
                 assertEquals(StudySessionConfigState.SessionType.VARIABLE, outputState.getSessionType());
                 assertEquals("Recursive correctness", outputState.getPrompt());
                 assertEquals("csc236.pdf", outputState.getReferenceFile());
 
-                assertNotNull(outputData.getStartTime()); // Make sure a start time was provided
+                // Make sure a start time was provided
+                assertNotNull(outputData.getStartTime());
             }
 
             @Override
@@ -105,14 +114,14 @@ class StartStudySessionTest {
             }
         };
 
-        StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter, database);
+        final StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter, database);
         interactor.execute(inputData);
 
     }
 
     @Test
     void abortConfigTest() {
-        StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
+        final StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
 
             @Override
             public void startStudySession(StartStudySessionOutputData outputData) {
@@ -135,25 +144,26 @@ class StartStudySessionTest {
             }
         };
 
-        StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter,
-                new InMemoryDatabase());
+        final StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter,
+            new InMemoryDatabase());
         interactor.abortStudySessionConfig();
     }
 
     @Test
     void failurePromptNotAddedTest() {
-        StartStudySessionDataAccessInterface database = new InMemoryDatabase(
-                Map.of("csc236.pdf", "csc236.pdf"));
-        StudySessionConfigState config = new StudySessionConfigState();
+        final StartStudySessionDataAccessInterface database = new InMemoryDatabase(
+            Map.of("csc236.pdf", "csc236.pdf"));
+        final StudySessionConfigState config = new StudySessionConfigState();
         config.setSessionType(StudySessionConfigState.SessionType.VARIABLE);
         config.setReferenceFile("csc236.pdf");
         // Prompt was not set, any other information is valid.
 
-        StartStudySessionInputData inputData = new StartStudySessionInputData(
-                config
+        final StartStudySessionInputData inputData = new StartStudySessionInputData(
+            "testUser",
+            config
         );
 
-        StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
+        final StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
 
             @Override
             public void startStudySession(StartStudySessionOutputData outputData) {
@@ -176,16 +186,16 @@ class StartStudySessionTest {
             }
         };
 
-        StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter,
-                database);
+        final StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter,
+            database);
         interactor.execute(inputData);
     }
 
     @Test
     void failureNoDurationSpecifiedFixedSessionTest() {
-        StartStudySessionDataAccessInterface database = new InMemoryDatabase(
-                Map.of("csc236.pdf", "csc236.pdf"));
-        StudySessionConfigState config = new StudySessionConfigState();
+        final StartStudySessionDataAccessInterface database = new InMemoryDatabase(
+            Map.of("csc236.pdf", "csc236.pdf"));
+        final StudySessionConfigState config = new StudySessionConfigState();
         config.setSessionType(StudySessionConfigState.SessionType.FIXED);
         config.setReferenceFile("csc236.pdf");
         // Total study target set to 0.
@@ -193,12 +203,12 @@ class StartStudySessionTest {
         config.setTargetDurationMinutes(0);
         config.setPrompt("Recursive correctness");
 
-        StartStudySessionInputData inputData = new StartStudySessionInputData(
-                config
+        final StartStudySessionInputData inputData = new StartStudySessionInputData(
+            "testUser",
+            config
         );
 
-        StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
-
+        final StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
             @Override
             public void startStudySession(StartStudySessionOutputData outputData) {
                 fail("Starting the session is unexpected.");
@@ -220,10 +230,44 @@ class StartStudySessionTest {
             }
         };
 
-        StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter,
-                database);
+        final StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter,
+            database);
         interactor.execute(inputData);
     }
 
-    // TODO: Add a test for refreshing file options.
+    @Test
+    void testFileRefresh() {
+        final StartStudySessionDataAccessInterface database = new InMemoryDatabase(
+            Map.of("csc236.pdf", "csc263.pdf",
+                "mat223.pdf", "mat223.pdf"));
+
+        final StartStudySessionOutputBoundary successPresenter = new StartStudySessionOutputBoundary() {
+            @Override
+            public void startStudySession(StartStudySessionOutputData outputData) {
+                fail("Starting the session is unexpected.");
+            }
+
+            @Override
+            public void prepareErrorView(String errorMessage) {
+                assertEquals("Please study a bit more seriously (time can't be zero)!", errorMessage);
+            }
+
+            @Override
+            public void abortStudySessionConfig() {
+                fail("Aborting the config is unexpected.");
+            }
+
+            @Override
+            public void refreshFileOptions(List<String> fileOptions) {
+                assertEquals("csc236.pdf", fileOptions.get(0));
+                assertEquals("mat223.pdf", fileOptions.get(1));
+            }
+        };
+
+        final StartStudySessionInputBoundary interactor = new StartStudySessionInteractor(successPresenter,
+            database);
+
+        interactor.refreshFileOptions("testUser");
+
+    }
 }


### PR DESCRIPTION
Updated so the `Controller`s will have access to the `DashboardViewModel`, where the currently logged in user's `userId` would be accessed with `dashboardViewModel.getState().getUserId()` instead of a static reference.