### PR TITLE
remove method call causing runtime exception

### DIFF
--- a/src/main/java/view/StudyMetricsView.java
+++ b/src/main/java/view/StudyMetricsView.java
@@ -69,8 +69,6 @@ public class StudyMetricsView extends View implements PropertyChangeListener {
 
         main.add(returnPanel, BorderLayout.SOUTH);
         this.add(main, BorderLayout.SOUTH);
-
-        SwingUtilities.invokeLater(this::loadMetrics);
     }
 
     @NotNull


### PR DESCRIPTION
Removed a call that ran in `StudyMetricsView` constructor that tries to load data before the user logs in

Closes #52 