### PR TITLE
full line coverage for start study session interactor

### DIFF
--- a/src/main/java/frameworks_drivers/database/InMemoryDatabase.java
+++ b/src/main/java/frameworks_drivers/database/InMemoryDatabase.java
@@ -1,40 +1,37 @@
 package frameworks_drivers.database;
 
-import entity.StudyQuiz;
-import entity.StudySession;
-import use_case.end_study_session.EndStudySessionDataAccessInterface;
-import use_case.start_study_session.StartStudySessionDataAccessInterface;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import entity.StudyQuiz;
+import entity.StudySession;
+import use_case.end_study_session.EndStudySessionDataAccessInterface;
+import use_case.start_study_session.StartStudySessionDataAccessInterface;
+
 /**
  * In memory database for study sessions and quizzes.
- * <p>
  * No multiuser functionality, assumes there's only one user.
  */
 public class InMemoryDatabase implements StartStudySessionDataAccessInterface, EndStudySessionDataAccessInterface {
 
     private final Map<String, StudySession> sessionTable;
     private final Map<String, StudyQuiz> quizTable;
-    private int sessionIdKey = 0; // Primary key for sessions
-    private int quizIdKey = 0; // Primary key for quizzes.
+    // Primary key for sessions
+    private int sessionIdKey;
+    // Primary key for quizzes.
+    private int quizIdKey;
 
+    // The keys are the filenames. The values are nothing
     private Map<String, String> fileStore;
 
     public InMemoryDatabase() {
         sessionTable = new HashMap<>();
         quizTable = new HashMap<>();
-
-        // Temporary removal until dummy file data in the application can be removed.
-        // fileStore = new HashMap<>();
-        fileStore = Map.of(
-                "mat223.pdf", "mat223.pdf",
-                "longer_textbook_name_adfasdf.pdf", "longer_textbook_name_adfasdf.pdf",
-                "csc222.pdf", "csc222.pdf",
-                "pdf.pdf", "pdf.pdf");
+        sessionIdKey = 0;
+        quizIdKey = 0;
+        fileStore = new HashMap<>();
     }
 
     public InMemoryDatabase(Map<String, String> initialFiles) {
@@ -43,7 +40,6 @@ public class InMemoryDatabase implements StartStudySessionDataAccessInterface, E
         fileStore = initialFiles;
     }
 
-    // TODO: detemrine how we are using files/file entity class
     public String uploadFile(String fileName, String file) {
         fileStore.put(fileName, file);
         return file;

--- a/src/main/java/use_case/start_study_session/StartStudySessionInteractor.java
+++ b/src/main/java/use_case/start_study_session/StartStudySessionInteractor.java
@@ -71,13 +71,8 @@ public class StartStudySessionInteractor implements StartStudySessionInputBounda
         return fileDataAccessObject.fileExistsByName(userId, file);
     }
 
-    // TODO: Either remove this and move this to navigation from dashboard to config
-    // view, or
-    // make sure this is called when the config view is opened somehow.
     @Override
     public void refreshFileOptions(String userId) {
-
-        // TODO: Use real user ID
         final List<String> fileOptions = fileDataAccessObject.getAllUserFiles(userId);
         if (fileOptions == null || fileOptions.isEmpty()) {
             presenter.prepareErrorView("No textbook files. Go to the settings and add some first.");


### PR DESCRIPTION
Addition of more tests to achieve full 100% line coverage for the `StartStudySessionInteractor` tests.

Note that a change to the `InMemoryDatabase` was done to remove the sample startup files for a no-parameter constructor.

All new changes focus on minimizing new checkstyle errors.